### PR TITLE
Adds the `unused` linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,8 @@ linters:
   disable:
     - bodyclose # we use don't use pure http very often and all API clients already close the body for us
     - exportloopref # this pattern is fixed in golang 1.22 https://github.com/kyoh86/exportloopref
+  enable:
+    - unused
   presets:
     - bugs
 


### PR DESCRIPTION
This linter seems to be quite a lot better than the `deadcode` linter according to the PR where `deadcode` was deprecated within golangci-lint: https://github.com/golangci/golangci-lint/issues/1841

The problems with our current use of deadcode are:

* It requires an additional install and testing step
* It doesn't show up in VSCode which is really annoying
* The way we're doing ignoring, while simple is extremely hard to maintain, since each time the line number of the ignored code changes, we have to update the ignore line number or we'll get a diff e.g.

      3,4c3,4
      Error: < server/main.go:480:22: unreachable func: ServerError.Error
      Error: < server/main.go:484:22: unreachable func: ServerError.Unwrap
      ---
      Error: > server/main.go:484:22: unreachable func: ServerError.Error
      Error: > server/main.go:488:22: unreachable func: ServerError.Unwrap
      Error: Process completed with exit code 1.

Once this is merged we will be able to remove the deadcode check from all of our CI/CD pipelines